### PR TITLE
Update the actual file creation logic and comparaison

### DIFF
--- a/src/Test/Hspec/Golden.hs
+++ b/src/Test/Hspec/Golden.hs
@@ -83,21 +83,17 @@ runGolden Golden{..} =
    in do
      createDirectoryIfMissing True goldenTestDir
      goldenFileExist <- doesFileExist goldenFilePath
-     actualFileExist <- doesFileExist actualFilePath
-     case (goldenFileExist, actualFileExist) of
-       (False, _)    -> writeToFile goldenFilePath output
-                             >> return FirstExecution
-       (True, False) -> do
+
+     -- the actual file is always written, this way, hgold will always
+     -- upgrade based on the latest run
+     writeToFile actualFilePath output
+
+     if not goldenFileExist
+       then writeToFile goldenFilePath output
+            >> return FirstExecution
+       else do
           contentGolden <- readFromFile goldenFilePath
+
           if contentGolden == output
              then return SameOutput
-             else writeToFile actualFilePath output
-                    >> return MissmatchOutput
-
-       (True, True) -> do
-          contentGolden <- readFromFile goldenFilePath
-          contentActual <- readFromFile actualFilePath
-          if contentGolden == contentActual
-             then return SameOutput
-             else writeToFile actualFilePath output
-                    >> return MissmatchOutput
+             else return MissmatchOutput

--- a/test/Test/Hspec/GoldenSpec.hs
+++ b/test/Test/Hspec/GoldenSpec.hs
@@ -46,9 +46,10 @@ spec =
          goldenFileContent <- readFile goldenFile
          goldenFileContent `shouldBe` fixtureContent
 
-      it "shouldn't create a `actual` file" $ do
-        void $ runSpec $ fixtureTest fixtureContent
-        doesFileExist actualFile `shouldReturn` False
+      it "should create a `actual` file" $ do
+         void $ runSpec $ fixtureTest fixtureContent
+         actualFileContent <- readFile goldenFile
+         actualFileContent `shouldBe` fixtureContent
 
     context "when the output is updated" $
       context "when the test is executed a second time" $ do
@@ -72,8 +73,3 @@ spec =
            void $ runSpec $ fixtureTest fixtureContent
            goldenFileContent <- readFile goldenFile
            goldenFileContent `shouldBe` fixtureContent
-
-        it "shouldn't create the `actual` output file" $ do
-           void $ runSpec $ fixtureTest fixtureContent
-           void $ runSpec $ fixtureTest fixtureContent
-           doesFileExist actualFile `shouldReturn` False


### PR DESCRIPTION
Actual file are now created in all circumpstances, now including:

- When a golden file is created, an identical actual file is
  created. This will prevent an override of the golden file by hgold
  using any leftover actual file from potential previous runs
- When a test leads to the same output as the golden file, the actual
  file is also updated, preventing an ovveride of the golden file by
  hgold.
- When a test leads to a different output, the actual file is updated,
  this is similar to the previous behavior.

Moreover this fix two annoying bugs:

- Previous comparaison logic wasn't using the new output.
- Due to lazy IO, the comparaison between golden and actual file
  content may not consume all the input, leading to unclosed actual
  file. This actual file was later written, leading to an exception
  "file locked".

- Update tests accordingly