### PR TITLE
Display difference in the error output of the test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ import qualified Data.Text.IO as T
 myGoldenTest :: String -> Text -> Golden Text
 myGoldenTest name actualOutput =
   Golden {
-    output = actualOutput
-    writeToFile = T.writeFile
-    readFromFile = T.readFile
-    testName = name
+    output = actualOutput,
+    encodePretty = prettyText,
+    writeToFile = T.writeFile,
+    readFromFile = T.readFile,
+    testName = name,
     directory = ".myGoldenTestDir"
   }
 

--- a/examples/html/.golden/html_pretty/golden
+++ b/examples/html/.golden/html_pretty/golden
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>
+            Stack Builders
+        </title>
+    </head>
+    <body>
+        <div>
+            <p>
+                Hello World!
+            </p>
+        </div>
+    </body>
+</html>

--- a/examples/html/package.yaml
+++ b/examples/html/package.yaml
@@ -24,6 +24,8 @@ tests:
     main:                Spec.hs
     source-dirs:         test
     dependencies:
+    - text
     - html
     - hspec
     - hspec-golden
+    - pretty-simple

--- a/examples/html/test/HtmlSpec.hs
+++ b/examples/html/test/HtmlSpec.hs
@@ -1,13 +1,20 @@
 module HtmlSpec (spec) where
 
-import           Html              (htmlRendered)
+import qualified Data.Text.Lazy     as T
+import           Html               (htmlRendered)
 import           Test.Hspec
 import           Test.Hspec.Golden
+import           Text.Pretty.Simple (pString)
 
 
 spec :: Spec
 spec =
-  describe "html" $
+  describe "html" $ do
     context "given a valid generated html" $
       it "generates html" $
         defaultGolden "html" htmlRendered
+
+    context "given a valid generated html" $
+      it "generates html (error encoded pretty)" $
+        (defaultGolden "html_pretty" htmlRendered)
+           { encodePretty = T.unpack . pString }

--- a/src/Test/Hspec/Golden.hs
+++ b/src/Test/Hspec/Golden.hs
@@ -1,12 +1,26 @@
+{-|
+Module      : Test.Hspec.Golden
+Description : Golden tests for Hspec
+Copyright   : Stack Builders (c), 2019
+License     : MIT
+Maintainer  : cmotoche@stackbuilders.com
+Stability   : experimental
+Portability : portable
+
+Golden tests store the expected output in a separated file. Each time a golden test
+is executed the output of the subject under test (SUT) is compared with the
+expected output. If the output of the SUT changes then the test will fail until
+the expected output is updated. We expose 'defaultGolden' for output of
+type @String@. If your SUT has a different output, you can use 'Golden'.
+-}
+
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeFamilies      #-}
 
 module Test.Hspec.Golden
   ( Golden(..)
-  , GoldenResult(..)
   , defaultGolden
-  , runGolden
   )
   where
 
@@ -17,6 +31,26 @@ import           Test.Hspec.Core.Spec (Example (..), FailureReason (..),
 
 
 -- | Golden tests parameters
+--
+-- @
+-- import           Data.Text (Text)
+-- import qualified Data.Text.IO as T
+--
+-- goldenText :: String -> Text -> Golden Text
+-- goldenText name actualOutput =
+--   Golden {
+--     output = actualOutput,
+--     encodePretty = prettyText,
+--     writeToFile = T.writeFile,
+--     readFromFile = T.readFile,
+--     testName = name,
+--     directory = ".specific-golden-dir"
+--   }
+--
+-- describe "myTextFunc" $
+--   it "generates the right output with the right params" $
+--     goldenText "myTextFunc" (myTextFunc params)
+-- @
 
 data Golden str =
   Golden {
@@ -51,6 +85,13 @@ fromGoldenResult (MissmatchOutput expected actual) =
          (Failure Nothing (ExpectedButGot Nothing expected actual))
 
 -- | An example of Golden tests which output is 'String'
+--
+-- @
+--  describe "html" $ do
+--    context "given a valid generated html" $
+--      it "generates html" $
+--        defaultGolden "html" someHtml
+-- @
 
 defaultGolden :: String -> String -> Golden String
 defaultGolden name output_ =


### PR DESCRIPTION
I decided to delegate the user to choose the way in which the output is going to be encoded if the test fails. For the `defaultGolden` the users would use the `Show` of `String`. However, they can change it if they want. For instance, in the example `example/html` I used `pString` from [pretty-simple](https://hackage.haskell.org/package/pretty-simple) to display the error. 

The following screenshot shows at the beginning a display of the string comparison using `show` in the other case I used `pString`:

![image](https://user-images.githubusercontent.com/8370088/59704235-3840d780-91c1-11e9-9188-69fe51ff363d.png)