### PR TITLE
Add "fileExtension" configuration field

### DIFF
--- a/hspec-golden.cabal
+++ b/hspec-golden.cabal
@@ -37,6 +37,7 @@ library
   build-depends:
       base >=4.6 && <5
     , directory
+    , filepath >=1.0 && <2.0
     , hspec-core >=2.5 && <3.0
   default-language: Haskell2010
 

--- a/src/Test/Hspec/Golden.hs
+++ b/src/Test/Hspec/Golden.hs
@@ -26,6 +26,7 @@ module Test.Hspec.Golden
 
 import           Data.IORef
 import           System.Directory     (createDirectoryIfMissing, doesFileExist)
+import           System.FilePath      ((<.>), (</>))
 import           Test.Hspec.Core.Spec (Example (..), FailureReason (..),
                                        Result (..), ResultStatus (..))
 
@@ -43,6 +44,7 @@ import           Test.Hspec.Core.Spec (Example (..), FailureReason (..),
 --     encodePretty = prettyText,
 --     writeToFile = T.writeFile,
 --     readFromFile = T.readFile,
+--     fileExtension = "txt",
 --     testName = name,
 --     directory = ".specific-golden-dir",
 --     failFirstTime = False
@@ -59,6 +61,7 @@ data Golden str =
     encodePretty  :: str -> String, -- ^ Makes the comparison pretty when the test fails
     writeToFile   :: FilePath -> str -> IO (), -- ^ How to write into the golden file the file
     readFromFile  :: FilePath -> IO str, -- ^ How to read the file,
+    fileExtension :: String, -- ^ The file extension to be used for the created test files (For example: "txt", "hs")
     testName      :: String, -- ^ Test name (make sure it's unique otherwise it could be override)
     directory     :: FilePath, -- ^ Directory where you write your tests
     failFirstTime :: Bool -- ^ Whether to record a failure the first time this test is run
@@ -106,6 +109,7 @@ defaultGolden name output_ =
     testName = name,
     writeToFile = writeFile,
     readFromFile = readFile,
+    fileExtension = "",
     directory = ".golden",
     failFirstTime = False
   }
@@ -122,9 +126,9 @@ data GoldenResult =
 
 runGolden :: Eq str => Golden str -> IO GoldenResult
 runGolden Golden{..} =
-  let goldenTestDir = directory ++ "/" ++ testName
-      goldenFilePath = goldenTestDir ++ "/" ++ "golden"
-      actualFilePath = goldenTestDir ++ "/" ++ "actual"
+  let goldenTestDir = directory </> testName
+      goldenFilePath = goldenTestDir </> "golden" <.> fileExtension
+      actualFilePath = goldenTestDir </> "actual" <.> fileExtension
    in do
      createDirectoryIfMissing True goldenTestDir
      goldenFileExist <- doesFileExist goldenFilePath


### PR DESCRIPTION
This fixes #23 

I've added the "filepath" library as a dependency because its `<.>` operator properly handles the case of adding an empty extension, and it's a known library so the code is very clear.

If this is not good then I can rewrite the code without "filepath". I can also make any other changes that are needed.

Thank you

