### PR TITLE
More flexible file locations

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,7 @@ import           System.Directory      (doesDirectoryExist, doesFileExist,
 import qualified Test.Hspec.Golden     as G
 
 defaultDirGoldenTest :: FilePath
-defaultDirGoldenTest = G.directory (G.defaultGolden "" "")
+defaultDirGoldenTest = ".golden"
 
 -- CLI Params
 

--- a/hspec-golden.cabal
+++ b/hspec-golden.cabal
@@ -37,6 +37,7 @@ library
   build-depends:
       base >=4.6 && <5
     , directory
+    , filepath >=1.0 && <2.0
     , hspec-core >=2.5 && <3.0
   default-language: Haskell2010
 

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ library:
     - Test.Hspec.Golden
   dependencies:
   - directory
+  - filepath >=1.0 && <2.0
   - hspec-core >= 2.5 && < 3.0
 
 executables:

--- a/test/Test/Hspec/GoldenSpec.hs
+++ b/test/Test/Hspec/GoldenSpec.hs
@@ -18,7 +18,7 @@ fixtureContent = "simple text"
 fixtureTestName = "id"
 
 goldenTestDir, goldenFile, actualFile :: FilePath
-goldenTestDir = directory (defaultGolden "" "") ++ "/" ++ "id"
+goldenTestDir = ".golden" ++ "/" ++ "id"
 goldenFile = goldenTestDir ++ "/" ++ "golden"
 actualFile = goldenTestDir ++ "/" ++ "actual"
 

--- a/test/Test/Hspec/GoldenSpec.hs
+++ b/test/Test/Hspec/GoldenSpec.hs
@@ -17,10 +17,10 @@ fixtureUpdatedContent = "different text"
 fixtureContent = "simple text"
 fixtureTestName = "id"
 
-goldenTestDir, goldenFile, actualFile :: FilePath
+goldenTestDir, goldenFilePath, actualFilePath :: FilePath
 goldenTestDir = ".golden" ++ "/" ++ "id"
-goldenFile = goldenTestDir ++ "/" ++ "golden"
-actualFile = goldenTestDir ++ "/" ++ "actual"
+goldenFilePath = goldenTestDir ++ "/" ++ "golden"
+actualFilePath = goldenTestDir ++ "/" ++ "actual"
 
 fixtureTest :: String -> H.Spec
 fixtureTest content =
@@ -43,12 +43,12 @@ spec =
     context "when the test is executed for the first time" $ do
       it "should create a `golden` file" $ do
          void $ runSpec $ fixtureTest fixtureContent
-         goldenFileContent <- readFile goldenFile
+         goldenFileContent <- readFile goldenFilePath
          goldenFileContent `shouldBe` fixtureContent
 
       it "should create a `actual` file" $ do
          void $ runSpec $ fixtureTest fixtureContent
-         actualFileContent <- readFile goldenFile
+         actualFileContent <- readFile goldenFilePath
          actualFileContent `shouldBe` fixtureContent
 
     context "when the output is updated" $
@@ -56,13 +56,13 @@ spec =
         it "should create the `actual` output file" $ do
            void $ runSpec $ fixtureTest fixtureContent
            void $ runSpec $ fixtureTest fixtureUpdatedContent
-           actualFileContent <- readFile actualFile
+           actualFileContent <- readFile actualFilePath
            actualFileContent `shouldBe` fixtureUpdatedContent
 
         it "shouldn't overide the `golden` file" $ do
            void $ runSpec $ fixtureTest fixtureContent
            void $ runSpec $ fixtureTest fixtureUpdatedContent
-           goldenFileContent <- readFile goldenFile
+           goldenFileContent <- readFile goldenFilePath
            goldenFileContent `shouldBe` fixtureContent
 
 
@@ -71,5 +71,5 @@ spec =
         it "shouldn't change the `golden` file content" $ do
            void $ runSpec $ fixtureTest fixtureContent
            void $ runSpec $ fixtureTest fixtureContent
-           goldenFileContent <- readFile goldenFile
+           goldenFileContent <- readFile goldenFilePath
            goldenFileContent `shouldBe` fixtureContent


### PR DESCRIPTION
This fixes #23 and #13

Removes the fields `testName` and `directory` and replaces them with `goldenFile` and `actualFile`. This allows a lot more flexibility:

  - Custom file names and/or custom file extensions
  - Custom directory locations
  - Option to not save "actual" files

This pull request has 2 commits. The first commit maintains the `testName` field, but I think things are cleaner and simpler without it (2nd commit).

The `hgold` program isn't aware of the changes made, but will still continue to work if you use `defaultGolden` (the default directory and file names).