### PR TITLE
Add IO instance

### DIFF
--- a/src/Test/Hspec/Golden.hs
+++ b/src/Test/Hspec/Golden.hs
@@ -69,6 +69,19 @@ instance Eq str => Example (Golden str) where
   type Arg (Golden str) = ()
   evaluateExample e = evaluateExample (\() -> e)
 
+instance Eq str => Example (IO (Golden str)) where
+  type Arg (IO (Golden str)) = ()
+  evaluateExample e = evaluateExample (\() -> e)
+
+instance Eq str => Example (arg -> IO (Golden str)) where
+  type Arg (arg -> IO (Golden str)) = arg
+  evaluateExample golden _ action _ = do
+    ref <- newIORef (Result "" Success)
+    action $ \arg -> do
+      r <- runGolden =<< golden arg
+      writeIORef ref (fromGoldenResult r)
+    readIORef ref
+
 instance Eq str => Example (arg -> Golden str) where
   type Arg (arg -> Golden str) = arg
   evaluateExample golden _ action _ = do

--- a/test/Test/Hspec/GoldenSpec.hs
+++ b/test/Test/Hspec/GoldenSpec.hs
@@ -66,7 +66,7 @@ spec =
            goldenFileContent `shouldBe` fixtureContent
 
     context "when IO actions are needed in the test case" $
-      it "`defaultGolden` should be accessible from the test case" $ do
+      it "enables `defaultGolden` to be accessible from the test case" $ do
         void $ runSpec $ fixtureTest fixtureContent
         result <- readFile goldenFilePath
         pure $ defaultGolden "io-test" result

--- a/test/Test/Hspec/GoldenSpec.hs
+++ b/test/Test/Hspec/GoldenSpec.hs
@@ -65,6 +65,11 @@ spec =
            goldenFileContent <- readFile goldenFilePath
            goldenFileContent `shouldBe` fixtureContent
 
+    context "running on IO" $
+      it "works" $ do
+        void $ runSpec $ fixtureTest fixtureContent
+        result <- readFile goldenFilePath
+        pure $ defaultGolden "foo" result
 
     context "when the output is not updated" $
       context "when the test is executed a second time" $

--- a/test/Test/Hspec/GoldenSpec.hs
+++ b/test/Test/Hspec/GoldenSpec.hs
@@ -65,11 +65,11 @@ spec =
            goldenFileContent <- readFile goldenFilePath
            goldenFileContent `shouldBe` fixtureContent
 
-    context "running on IO" $
-      it "works" $ do
+    context "when IO actions are needed in the test case" $
+      it "`defaultGolden` should be accessible from the test case" $ do
         void $ runSpec $ fixtureTest fixtureContent
         result <- readFile goldenFilePath
-        pure $ defaultGolden "foo" result
+        pure $ defaultGolden "io-test" result
 
     context "when the output is not updated" $
       context "when the test is executed a second time" $


### PR DESCRIPTION
We may want to do some actions that return a Golden test. There are some workarounds at the moment, but it will be convenient to have an IO instance for `Golden`. For instance we could do something like:

```hs
    goldenTest :: String -> IO (Golden String)
    goldenTest str = do
      lookupEnv str >>= \case
        Nothing -> throwIO $ AssertionFailed (str ++ " Not found")
        Just s -> defaultGolden s <$> someIOAction
```

For that we need to add an [Example Instance](https://hackage.haskell.org/package/hspec-2.10.10/docs/Test-Hspec.html#t:Example) to `IO Golden`