### PR TITLE
doc: Fix badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hspec-golden
-[![Build and Test](https://github.com/stackbuilders/hspec-golden/actions/workflows/build-and-test.yml/badge.svg?branch=master)](https://github.com/stackbuilders/hspec-golden/actions/workflows/build-and-test.yml) [![Hackage](https://img.shields.io/hackage/v/dotenv.svg)](http://hackage.haskell.org/package/dotenv)
+[![Build and Test](https://github.com/stackbuilders/hspec-golden/actions/workflows/build-and-test.yml/badge.svg?branch=master)](https://github.com/stackbuilders/hspec-golden/actions/workflows/build-and-test.yml) [![Hackage](https://img.shields.io/hackage/v/hspec-golden.svg)](http://hackage.haskell.org/package/hspec-golden)
 
 ## Description
 Golden tests store the expected output in a separated file. Each time a golden test


### PR DESCRIPTION
# Change
Fix badge. It was pointing to `dotenv`.
