### PR TITLE
feat: Include colors for hgold CLI output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Changelog for hspec-golden
+## 0.2.1.1
+#### Add
+* Add colors to hspec-golden CLI tool.
+
 ## 0.2.1.0
 #### Add
 * Instance for IO Golden type. Kudos to @dbalseiro

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           System.Console.ANSI
 import           Control.Monad         (forM_, when)
 import           Data.Version          (showVersion)
 import           Paths_hspec_golden    (version)
@@ -14,14 +15,10 @@ defaultDirGoldenTest = ".golden"
 
 -- CLI Params
 
-data Params =
-    Params
-      { updateDir    :: FilePath 
-   --   , shouldUpdate :: Bool
-      } deriving Show
-  
+newtype Params = Params { updateDir :: FilePath } deriving Show
+
 params :: Parser Params
-params = Params 
+params = Params
       <$> strOption
           (long "update"
           <> short 'u'
@@ -31,18 +28,29 @@ params = Params
           <> help "The testing directory where you're dumping your results.")
 
 versionOpt :: Parser (a->a)
-versionOpt = infoOption (showVersion version) 
+versionOpt = infoOption (showVersion version)
               (long "version"
-              <> short 'v'  
+              <> short 'v'
               <> help "Show version")
-            
 
---Update Files
+putStrColor :: Color -> String -> IO ()
+putStrColor color str = do
+  setSGR [SetColor Foreground Dull color]
+  putStr str
+  setSGR [Reset]
+
+putStrLnColor :: Color -> String -> IO ()
+putStrLnColor color str = do
+  setSGR [SetColor Foreground Dull color]
+  putStrLn str
+  setSGR [Reset]
+
+-- Update Files
 updateGolden :: FilePath -> IO ()
 updateGolden dir = do
-  putStrLn "Replacing golden with actual..."
+  putStrLnColor Yellow "Replacing golden with actual:"
   go dir
-  putStrLn "Finish..."
+  putStrLnColor Green "Finished!"
  where
   go dir = do
     entries <- listDirectory dir
@@ -60,7 +68,11 @@ mvActualToGolden testPath =
    in do
      actualFileExist <- doesFileExist actualFilePath
      when actualFileExist (do
-       putStrLn $ "  Replacing file: " ++ goldenFilePath ++ " with: " ++ actualFilePath
+       putStr "  Replacing file: "
+       putStrColor Yellow goldenFilePath
+       putStr " with: "
+       putStrColor Green actualFilePath
+       putStrLn ""
        renameFile actualFilePath goldenFilePath)
 
 

--- a/hspec-golden.cabal
+++ b/hspec-golden.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.35.5.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hspec-golden
-version:        0.2.1.0
+version:        0.2.1.
 synopsis:       Golden tests for hspec
 description:    .
                 Golden tests store the expected output in a separated file. Each time a golden test
@@ -61,7 +61,8 @@ executable hgold
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.6 && <5
+      ansi-terminal >=1.0 && <2.0
+    , base >=4.6 && <5
     , directory >=1.2.5.0
     , hspec-golden
     , optparse-applicative

--- a/hspec-golden.cabal
+++ b/hspec-golden.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hspec-golden
-version:        0.2.1.
+version:        0.2.1.1
 synopsis:       Golden tests for hspec
 description:    .
                 Golden tests store the expected output in a separated file. Each time a golden test

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hspec-golden
-version:             0.2.1.0
+version:             0.2.1.
 github:              "stackbuilders/hspec-golden"
 license:             MIT
 author:              "Stack Builders"
@@ -53,6 +53,7 @@ executables:
     - hspec-golden
     - directory >= 1.2.5.0
     - optparse-applicative
+    - ansi-terminal >= 1.0 && < 2.0
 
 tests:
   hspec-golden-test:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hspec-golden
-version:             0.2.1.
+version:             0.2.1.1
 github:              "stackbuilders/hspec-golden"
 license:             MIT
 author:              "Stack Builders"


### PR DESCRIPTION
Adding colors to Hspec Golden CLI:

![image](https://github.com/stackbuilders/hspec-golden/assets/8370088/67b137cd-2f33-4bfd-abb4-f4931c3a94ef)

---

As part of [Stack Builders Inc.](https://www.stackbuilders.com) Hacktoberfest 2023 event.
