### PR TITLE
fix: Remove docs generation on release build

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
       {
         "packageName": "hspec-golden",
         "versionPrefix": "0.",
-        "publishDocumentation": true
+        "publishDocumentation": false
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
Remove docs generation on CI since it's causing some failures
