### PR TITLE
Allow optparse-applicative ^>=0.19

### DIFF
--- a/hspec-golden.cabal
+++ b/hspec-golden.cabal
@@ -67,7 +67,7 @@ executable hgold
     , base >=4.6 && <5
     , directory >=1.2.5.0
     , hspec-golden
-    , optparse-applicative >=0.18.1 && <0.19
+    , optparse-applicative >=0.18.1 && <0.20
   default-language: Haskell2010
 
 test-suite hspec-golden-test


### PR DESCRIPTION
Tested with `cabal run --constraint 'optparse-applicative ^>=0.19' hgold -- --help`.

Can we please also have a metadata revision against the current release of `hspec-golden`?